### PR TITLE
API Gateway を REST から HTTP API に変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "lodash": "4.17.21",
         "nuxt": "2.15.6",
         "nuxt-start": "2.15.6",
-        "serverless-apigw-binary": "0.4.4",
         "serverless-http": "2.7.0",
         "vue-virtual-scroller": "1.0.10"
       },
@@ -22808,14 +22807,6 @@
       },
       "engines": {
         "node": ">=10.0"
-      }
-    },
-    "node_modules/serverless-apigw-binary": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/serverless-apigw-binary/-/serverless-apigw-binary-0.4.4.tgz",
-      "integrity": "sha512-2DJmQTzeXa/+8u9ekReqf7j4gQjBtzQE4MK9nlOnEz4F7MVWCQXYlLPmf2TXSoxxJZzlWvIiNzCTq6vAT9F5FQ==",
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/serverless-domain-manager": {
@@ -46399,11 +46390,6 @@
           "dev": true
         }
       }
-    },
-    "serverless-apigw-binary": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/serverless-apigw-binary/-/serverless-apigw-binary-0.4.4.tgz",
-      "integrity": "sha512-2DJmQTzeXa/+8u9ekReqf7j4gQjBtzQE4MK9nlOnEz4F7MVWCQXYlLPmf2TXSoxxJZzlWvIiNzCTq6vAT9F5FQ=="
     },
     "serverless-domain-manager": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "lodash": "4.17.21",
     "nuxt": "2.15.6",
     "nuxt-start": "2.15.6",
-    "serverless-apigw-binary": "0.4.4",
     "serverless-http": "2.7.0",
     "vue-virtual-scroller": "1.0.10"
   },

--- a/serverless.yml
+++ b/serverless.yml
@@ -6,21 +6,22 @@ provider:
   stage: ${opt:stage, self:custom.defaultStage}
   region: ap-northeast-1
   logRetentionInDays: 30
-  timeout: 30
+  timeout: 20
   versionFunctions: false
   lambdaHashingVersion: 20201221
   environment:
     NODE_ENV: ${self:provider.stage}
+  apiGateway:
+    binaryMediaTypes:
+      - '*/*'
 
 functions:
   nuxt:
     handler: server/index.nuxt
     events:
-      - http: ANY /
-      - http: ANY /{proxy+}
+      - httpApi: '*'
 
 plugins:
-  - serverless-apigw-binary
   - serverless-domain-manager
   - serverless-offline
 
@@ -29,11 +30,10 @@ custom:
   environment:
     dev: ${file(./config/development.yml)}
     prod: ${file(./config/production.yml)}
-  apigwBinary:
-    types:
-      - '*/*'
   customDomain:
     domainName: ${self:custom.environment.${self:provider.stage}.domain}
     basePath: ''
     stage: ${self:provider.stage}
     createRoute53Record: true
+    endpointType: regional
+    apiType: http


### PR DESCRIPTION
## 概要
HTTP API にすると REST と比べコストが7割減となるため移行

## 参考
- HTTP API (API Gateway v2)
   - https://www.serverless.com/framework/docs/providers/aws/events/http-api
- serverless-apigw-binary の移行
   - https://www.serverless.com/blog/framework-release-v142
- endpointType の指定
   - https://www.serverless.com/plugins/serverless-domain-manager